### PR TITLE
Issue #115: Check if downloaded file exists

### DIFF
--- a/TS3UpdateScript
+++ b/TS3UpdateScript
@@ -473,7 +473,7 @@ function getLatestTSServerVersion() {
 		TS3_SERVER_VERSION="$(getLatestStableTS3ServerVersion)";
 	fi
 
-	if [[ -n "$TS3_SERVER_VERSION" ]] && [[ "$TS3_SERVER_VERSION" != "0" ]]; then
+	if [[ -n "$TS3_SERVER_VERSION" ]] && [[ "$TS3_SERVER_VERSION" != "1" ]]; then
 		echo -n "$TS3_SERVER_VERSION";
 	else
 		return 1;

--- a/TS3UpdateScript
+++ b/TS3UpdateScript
@@ -1762,6 +1762,10 @@ function updateTeamSpeakInstance() {
 
 		wget ${TS3_SERVER_DOWNLOAD_LINK} -q -O teamspeak3-server.tar.bz2
 
+		if [[ ! -f "teamspeak3-server.tar.bz2" ]]; then
+			return 1;
+		fi
+
 		if [[ -f ${INSTANCE_PATH}/tsdns/tsdnsserver_${INSTALLED_TS3_SERVER_PLATFORM}_${TS3SERVER_ARCHITECTURE} ]]; then
 			rm -rf ${INSTANCE_PATH}/tsdns/tsdnsserver_${INSTALLED_TS3_SERVER_PLATFORM}_${TS3SERVER_ARCHITECTURE}
 		fi

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -26,6 +26,7 @@ Hotfix | Important fix for one more issues, which causes a not (correct) working
 ### Version 6.0.2 (2022-11-23)
 
 	+ Implement check for downloaded TeamSpeak server files
+	* Fixed incorrect check if the latest TeamSpeak server version could be detected or not. The script will now abort in case of failures.
 
 ### Version 6.0.1 (2022-11-23)
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -23,6 +23,10 @@ Hotfix | Important fix for one more issues, which causes a not (correct) working
 
 ## Releases
 
+### Version 6.0.2 (2022-11-23)
+
+	+ Implement check for downloaded TeamSpeak server files
+
 ### Version 6.0.1 (2022-11-23)
 
 	- Renamed `master` branch to `main`


### PR DESCRIPTION
Explicitly check for the downloaded file. If it doesn't exist, abort and fail instead of trying other follow up commands, which will fail anyway.