### PR TITLE
Replace deprecated `ts3-tools.info` domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ If you don't want to update your TeamSpeak 3 server manually, you can use this s
 
 ## Developers
 
-  * Sebastian Kraetzig [info@ts3-tools.info]
+  * Sebastian Kraetzig ([@Sebi94nbg](https://github.com/Sebi94nbg))
 
 ## Contributors
 

--- a/TS3UpdateScript
+++ b/TS3UpdateScript
@@ -2052,11 +2052,6 @@ function main() {
 
 	# Able to reach all needed remote server?
 	if [[ "$PAR_DEACTIVATE_HOST_ALIVE_CHECK" -eq 0 ]]; then
-		if ! testInternetConnectivity "www.ts3-tools.info"; then
-			echo "www.ts3-tools.info ${TXT_SELF_TEST_CONNECTIVITY}" >> SELF_TEST_STATUS.txt;
-			SELF_TEST_STATUS=1;
-		fi
-
 		if ! testInternetConnectivity "files.teamspeak-services.com"; then
 			echo "files.teamspeak-services.com ${TXT_SELF_TEST_CONNECTIVITY}" >> SELF_TEST_STATUS.txt;
 			SELF_TEST_STATUS=1;

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -23,6 +23,11 @@ Hotfix | Important fix for one more issues, which causes a not (correct) working
 
 ## Releases
 
+### Version 6.0.5 (2023-05-06)
+
+	* Remove connectivity check for the `ts3-tools.info` domain
+	* Replace `ts3-tools.info` domain in documentations with respective alternatives, if necessary
+
 ### Version 6.0.4 (2023-01-22)
 
 	* Fix `grep: docs/CHANGELOG.md: No such file or directory`

--- a/docs/INSTALL_USAGE_GUIDE.md
+++ b/docs/INSTALL_USAGE_GUIDE.md
@@ -231,7 +231,7 @@ or
 
 ## Debugging
 
-You will not need to debug and fix the issue by yourself. Just enable debugging of the script and send me the debug file via eMail to info@ts3-tools.info.
+You will not need to debug and fix the issue by yourself. Just enable debugging of the script and upload the debug file here on GitHub as a new issue.
 
 1. Execute the script with those parameters you want plus '--debug' and provide any non-existing filename
 


### PR DESCRIPTION
The `ts3-tools.info` domain isn't in use anymore by this script, so it can be fully removed from e.g. connectivity checks since they are mostly for ensuring, that the necessary resources are reachable.

Additional, some documentation sections get respectively updated.